### PR TITLE
exclude AssemblyInfo.fs from OpenCover as the new FAKE task generates…

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -110,6 +110,7 @@ Target "RunUnitTests" (fun _ ->
             TestRunnerExePath = "./packages/build/xunit.runner.console/tools/xunit.console.exe"
             Output = codeCoverageReport
             Register = RegisterType.RegisterUser
+            OptionalArguments = "-excludebyfile:*\*AssemblyInfo.fs -hideskipped:File"
             Filter = "+[JsonFs*]* -[*Tests]*"
         })
         (assembliesToTest + " -appveyor -noshadow")


### PR DESCRIPTION
… a utility class within that file, which is then picked up by the code coverage metrics.